### PR TITLE
Issues#97 １件毎に処理する仕組みを実装

### DIFF
--- a/typesafe-query-core/src/main/java/com/github/typesafe_query/DefaultFinder.java
+++ b/typesafe-query-core/src/main/java/com/github/typesafe_query/DefaultFinder.java
@@ -4,6 +4,8 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.github.typesafe_query.meta.DBTable;
 import com.github.typesafe_query.query.QueryExecutor;
@@ -19,6 +21,7 @@ import com.github.typesafe_query.util.Tuple;
  * <p>検索を行うクラスです</p>
  * 
  * TODO v0.3.x 再利用可能インスタンスを作成するファクトリメソッドを追加する？ #23
+ * TODO 同じようなコードが多いのでリファクタリングする
  * @author Takahiko Sato(MOSA architect Inc.)
  */
 public class DefaultFinder<I,T> implements Finder<I, T>{
@@ -270,5 +273,165 @@ public class DefaultFinder<I,T> implements Finder<I, T>{
 				.offset(offset)
 				.forOnce()
 				.getResultList(modelClass);
+	}
+
+	@Override
+	public void fetch(Predicate<T> p, Order... orders) {
+		Q.select().from(root).orderBy(orders).forOnce().fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetch(Predicate<T> p, int limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		Q.select()
+			.from(root)
+			.orderBy(orders)
+			.limit(limit)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetch(Predicate<T> p, int offset, int limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		
+		if(offset < 0){
+			throw new IllegalArgumentException("offset must be greater than -1");
+		}
+		
+		Q.select()
+			.from(root)
+			.limit(limit)
+			.orderBy(orders)
+			.offset(offset)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetch(Consumer<T> p, Order... orders) {
+		Q.select().from(root).orderBy(orders).forOnce().fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetch(Consumer<T> p, int limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		Q.select()
+			.from(root)
+			.orderBy(orders)
+			.limit(limit)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetch(Consumer<T> p, int offset, int limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		
+		if(offset < 0){
+			throw new IllegalArgumentException("offset must be greater than -1");
+		}
+		
+		Q.select()
+			.from(root)
+			.limit(limit)
+			.orderBy(orders)
+			.offset(offset)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetchWhere(Exp expression, Predicate<T> p, Order... orders) {
+		Q.select()
+			.from(root)
+			.where(expression)
+			.orderBy(orders)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetchWhere(Exp expression, Predicate<T> p, Integer limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		Q.select()
+			.from(root)
+			.where(expression)
+			.orderBy(orders)
+			.limit(limit)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetchWhere(Exp expression, Predicate<T> p, Integer offset, Integer limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		
+		if(offset < 0){
+			throw new IllegalArgumentException("offset must be greater than -1");
+		}
+		Q.select()
+			.from(root)
+			.where(expression)
+			.orderBy(orders)
+			.limit(limit)
+			.offset(offset)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetchWhere(Exp expression, Consumer<T> p, Order... orders) {
+		Q.select()
+			.from(root)
+			.where(expression)
+			.orderBy(orders)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetchWhere(Exp expression, Consumer<T> p, Integer limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		Q.select()
+			.from(root)
+			.where(expression)
+			.orderBy(orders)
+			.limit(limit)
+			.forOnce()
+			.fetch(modelClass, p);
+	}
+
+	@Override
+	public void fetchWhere(Exp expression, Consumer<T> p, Integer offset, Integer limit, Order... orders) {
+		if(limit < 1){
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		
+		if(offset < 0){
+			throw new IllegalArgumentException("offset must be greater than -1");
+		}
+		Q.select()
+			.from(root)
+			.where(expression)
+			.orderBy(orders)
+			.limit(limit)
+			.offset(offset)
+			.forOnce()
+			.fetch(modelClass, p);
 	}
 }

--- a/typesafe-query-core/src/main/java/com/github/typesafe_query/Finder.java
+++ b/typesafe-query-core/src/main/java/com/github/typesafe_query/Finder.java
@@ -5,6 +5,8 @@ package com.github.typesafe_query;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.github.typesafe_query.query.Exp;
 import com.github.typesafe_query.query.Order;
@@ -98,4 +100,17 @@ public interface Finder<I,T> {
 	 * @return 一覧
 	 */
 	List<T> listWhere(Exp expression,Integer offset,Integer limit,Order...orders);
+	
+	void fetch(Predicate<T> p, Order...orders);
+	void fetch(Predicate<T> p,int limit,Order...orders);
+	void fetch(Predicate<T> p,int offset,int limit,Order...orders);
+	void fetch(Consumer<T> p,Order...orders);
+	void fetch(Consumer<T> p,int limit,Order...orders);
+	void fetch(Consumer<T> p,int offset,int limit,Order...orders);
+	void fetchWhere(Exp expression,Predicate<T> p,Order...orders);
+	void fetchWhere(Exp expression,Predicate<T> p,Integer limit,Order...orders);
+	void fetchWhere(Exp expression,Predicate<T> p,Integer offset,Integer limit,Order...orders);
+	void fetchWhere(Exp expression,Consumer<T> p,Order...orders);
+	void fetchWhere(Exp expression,Consumer<T> p,Integer limit,Order...orders);
+	void fetchWhere(Exp expression,Consumer<T> p,Integer offset,Integer limit,Order...orders);
 }

--- a/typesafe-query-core/src/main/java/com/github/typesafe_query/jdbc/SQLRunner.java
+++ b/typesafe-query-core/src/main/java/com/github/typesafe_query/jdbc/SQLRunner.java
@@ -2,6 +2,7 @@ package com.github.typesafe_query.jdbc;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import com.github.typesafe_query.jdbc.mapper.ResultMapper;
 
@@ -14,6 +15,8 @@ public interface SQLRunner extends AutoCloseable{
 	<T> Optional<T> get(List<Object> params,ResultMapper<T> mapper);
 
 	<T> List<T> getList(List<Object> params,ResultMapper<T> mapper);
+	
+	<T> void fetch(List<Object> params,ResultMapper<T> mapper,Predicate<T> p);
 
 	int executeUpdate(List<Object> params);
 

--- a/typesafe-query-core/src/main/java/com/github/typesafe_query/query/QueryExecutor.java
+++ b/typesafe-query-core/src/main/java/com/github/typesafe_query/query/QueryExecutor.java
@@ -2,6 +2,8 @@ package com.github.typesafe_query.query;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.github.typesafe_query.jdbc.mapper.ResultMapper;
 
@@ -16,6 +18,10 @@ public interface QueryExecutor extends AutoCloseable{
 	<R> Optional<R> getResult(ResultMapper<R> mapper);
 	<R> List<R> getResultList(Class<R> modelClass);
 	<R> List<R> getResultList(ResultMapper<R> mapper);
+	<R> void fetch(Class<R> modelClass,Predicate<R> p);
+	<R> void fetch(ResultMapper<R> mapper,Predicate<R> p);
+	<R> void fetch(Class<R> modelClass,Consumer<R> p);
+	<R> void fetch(ResultMapper<R> mapper,Consumer<R> p);
 	
 	QueryExecutor clearParam();
 	QueryExecutor addParam(Object value);

--- a/typesafe-query-core/src/main/java/com/github/typesafe_query/query/internal/DefaultBatchQueryExecutor.java
+++ b/typesafe-query-core/src/main/java/com/github/typesafe_query/query/internal/DefaultBatchQueryExecutor.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.github.typesafe_query.DBManager;
 import com.github.typesafe_query.jdbc.mapper.ResultMapper;
@@ -83,6 +85,26 @@ public class DefaultBatchQueryExecutor extends AbstractQueryExecutor implements 
 
 	@Override
 	public <R> List<R> getResultList(ResultMapper<R> mapper) {
+		throw new UnsupportedOperationException("Unsupported when batch execution mode.");
+	}
+
+	@Override
+	public <R> void fetch(Class<R> modelClass, Predicate<R> p) {
+		throw new UnsupportedOperationException("Unsupported when batch execution mode.");
+	}
+
+	@Override
+	public <R> void fetch(ResultMapper<R> mapper, Predicate<R> p) {
+		throw new UnsupportedOperationException("Unsupported when batch execution mode.");
+	}
+
+	@Override
+	public <R> void fetch(Class<R> modelClass, Consumer<R> p) {
+		throw new UnsupportedOperationException("Unsupported when batch execution mode.");
+	}
+
+	@Override
+	public <R> void fetch(ResultMapper<R> mapper, Consumer<R> p) {
 		throw new UnsupportedOperationException("Unsupported when batch execution mode.");
 	}
 

--- a/typesafe-query-core/src/main/java/com/github/typesafe_query/query/internal/ReusableQueryExecutor.java
+++ b/typesafe-query-core/src/main/java/com/github/typesafe_query/query/internal/ReusableQueryExecutor.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import com.github.typesafe_query.DBManager;
 import com.github.typesafe_query.jdbc.mapper.BeanResultMapper;
@@ -90,6 +92,32 @@ public class ReusableQueryExecutor extends AbstractQueryExecutor implements Quer
 	@Override
 	public <R> List<R> getResultList(ResultMapper<R> mapper) {
 		return getSQLRunner().getList(params,mapper);
+	}
+
+	@Override
+	public <R> void fetch(Class<R> modelClass, Predicate<R> p) {
+		getSQLRunner().fetch(params, new BeanResultMapper<R>(modelClass), p);
+	}
+
+	@Override
+	public <R> void fetch(ResultMapper<R> mapper, Predicate<R> p) {
+		getSQLRunner().fetch(params, mapper, p);
+	}
+	
+	@Override
+	public <R> void fetch(Class<R> modelClass, Consumer<R> p) {
+		fetch(modelClass, r -> {
+			p.accept(r);
+			return true;
+		});
+	}
+
+	@Override
+	public <R> void fetch(ResultMapper<R> mapper, Consumer<R> p) {
+		fetch(mapper, r -> {
+			p.accept(r);
+			return true;
+		});
 	}
 
 	@Override

--- a/typesafe-query-core/src/test/java/com/github/typesafe_query/FinderTest.java
+++ b/typesafe-query-core/src/test/java/com/github/typesafe_query/FinderTest.java
@@ -13,6 +13,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Before;
@@ -247,5 +248,140 @@ public class FinderTest {
 		} catch (IllegalArgumentException e) {
 			
 		}
+	}
+	
+	@Test
+	public void fetch(){
+		
+		AtomicInteger ai = new AtomicInteger(0);
+		ApUser_.find().fetch(a -> {
+			assertNotNull(a);
+			ai.getAndIncrement();
+		});
+		assertThat(ai.get(), is(4));
+		
+		AtomicInteger ai2 = new AtomicInteger(0);
+		ApUser_.find().fetch(a -> {
+			assertNotNull(a);
+			ai2.getAndIncrement();
+			if(ai2.get() == 2){
+				return false;
+			}
+			return true;
+		});
+		
+		assertThat(ai2.get(), is(2));
+	}
+	
+	@Test
+	public void fetch_limit(){
+		
+		AtomicInteger ai = new AtomicInteger(0);
+		ApUser_.find().fetch(a -> {
+			assertNotNull(a);
+			ai.getAndIncrement();
+		},3);
+		assertThat(ai.get(), is(3));
+		
+		AtomicInteger ai2 = new AtomicInteger(0);
+		ApUser_.find().fetch(a -> {
+			assertNotNull(a);
+			ai2.getAndIncrement();
+			if(ai2.get() == 2){
+				return false;
+			}
+			return true;
+		},3);
+		
+		assertThat(ai2.get(), is(2));
+	}
+	
+	@Test
+	public void fetch_limit_offset(){
+		
+		AtomicInteger ai = new AtomicInteger(0);
+		ApUser_.find().fetch(a -> {
+			assertNotNull(a);
+			ai.getAndIncrement();
+		},2,2);
+		assertThat(ai.get(), is(2));
+		
+		AtomicInteger ai2 = new AtomicInteger(0);
+		ApUser_.find().fetch(a -> {
+			assertNotNull(a);
+			ai2.getAndIncrement();
+			if(ai2.get() == 2){
+				return false;
+			}
+			return true;
+		},2,2);
+		
+		assertThat(ai2.get(), is(2));
+	}
+	
+	@Test
+	public void fetchWhere(){
+		
+		AtomicInteger ai = new AtomicInteger(0);
+		ApUser_.find().fetchWhere(ApUser_.UNIT_ID.eq("U1"), a -> {
+			assertNotNull(a);
+			ai.getAndIncrement();
+		});
+		assertThat(ai.get(), is(3));
+		
+		AtomicInteger ai2 = new AtomicInteger(0);
+		ApUser_.find().fetchWhere(ApUser_.UNIT_ID.eq("U1"), a -> {
+			assertNotNull(a);
+			ai2.getAndIncrement();
+			if(ai2.get() == 2){
+				return false;
+			}
+			return true;
+		});
+		assertThat(ai2.get(), is(2));
+	}
+	
+	@Test
+	public void fetchWhere_limit(){
+		
+		AtomicInteger ai = new AtomicInteger(0);
+		ApUser_.find().fetchWhere(ApUser_.UNIT_ID.eq("U1"), a -> {
+			assertNotNull(a);
+			ai.getAndIncrement();
+		},2);
+		assertThat(ai.get(), is(2));
+		
+		AtomicInteger ai2 = new AtomicInteger(0);
+		ApUser_.find().fetchWhere(ApUser_.UNIT_ID.eq("U1"), a -> {
+			assertNotNull(a);
+			ai2.getAndIncrement();
+			if(ai2.get() == 2){
+				return false;
+			}
+			return true;
+		},2);
+		assertThat(ai2.get(), is(2));
+	}
+	
+	@Test
+	public void fetchWhere_limit_offset(){
+		
+		AtomicInteger ai = new AtomicInteger(0);
+		ApUser_.find().fetchWhere(ApUser_.UNIT_ID.eq("U1"), a -> {
+			assertNotNull(a);
+			ai.getAndIncrement();
+		},2,2);
+		assertThat(ai.get(), is(1));
+		
+		AtomicInteger ai2 = new AtomicInteger(0);
+		ApUser_.find().fetchWhere(ApUser_.UNIT_ID.eq("U1"), a -> {
+			assertNotNull(a);
+			ai2.getAndIncrement();
+			if(ai2.get() == 2){
+				return false;
+			}
+			return true;
+		},2,2);
+		assertThat(ai2.get(), is(1));
 	}
 }


### PR DESCRIPTION
- [x] `TypesafeQuery` で使えるように
- [x] `Finder` で使えるように

使い方

```
select()....forOnce().fetch(Customers.class, c -> System.out.println(c.getId()));

Customers.find().fetch(c -> {
   //Do something.
});
```

処理の中断
`Consumer` と `Predicate` がオーバーロードで定義してある。`true` で継続、 `false` を戻すとその時点で中断。

```
Customers.find().fetch(c -> {
   //Do something.
   if( hogehoge ){
      return false;
   }
   return true;
});

```
